### PR TITLE
#92 Add Deprecated field for scenarios

### DIFF
--- a/src/main/java/de/mehtrick/bjoern/generator/builder/BjoernScenarioTestMethodBuilder.java
+++ b/src/main/java/de/mehtrick/bjoern/generator/builder/BjoernScenarioTestMethodBuilder.java
@@ -38,6 +38,10 @@ public class BjoernScenarioTestMethodBuilder {
                 .addModifiers(Modifier.PUBLIC).addException(Exception.class).addJavadoc(scenario.getName());
         main.addAnnotation(junitVersion.getTestAnnotationClass());
         junitVersion.addExtraAnnotations(main,scenario);
+        if (scenario.isDeprecated()) {
+            main.addAnnotation(Deprecated.class);
+            main.addJavadoc("\n@deprecated Veraltet");
+        }
         if (scenario.getGiven() != null) {
             scenario.getGiven()
                     .forEach(given -> main.addStatement(BjoernStatementParser.createMethodCallOutOfStatemet(given)));

--- a/src/main/java/de/mehtrick/bjoern/parser/modell/BjoernScenario.java
+++ b/src/main/java/de/mehtrick/bjoern/parser/modell/BjoernScenario.java
@@ -13,10 +13,12 @@ import java.util.List;
  */
 public class BjoernScenario extends BjoernBackground {
     private String name;
+    private boolean deprecated;
     private List<BjoernStatement> when = new ArrayList<>();
 
     public BjoernScenario(BjoernZGRScenario bjoernZGRScenario) {
         setName(bjoernZGRScenario.getScenario());
+        setDeprecated(bjoernZGRScenario.isDeprecated());
         this.setGiven(parseStatements(bjoernZGRScenario.getGiven(), BDDKeyword.GIVEN));
         this.setWhen(parseStatements(bjoernZGRScenario.getWhen(), BDDKeyword.WHEN));
         this.setThen(parseStatements(bjoernZGRScenario.getThen(), BDDKeyword.THEN));
@@ -34,6 +36,14 @@ public class BjoernScenario extends BjoernBackground {
         this.name = name;
     }
 
+    public boolean isDeprecated() {
+        return this.deprecated;
+    }
+
+    public void setDeprecated(boolean deprecated) {
+        this.deprecated = deprecated;
+    }
+
     public List<BjoernStatement> getWhen() {
         return this.when;
     }
@@ -43,7 +53,7 @@ public class BjoernScenario extends BjoernBackground {
     }
 
     public String toString() {
-        return "BjoernScenario(name=" + this.getName() + ", when=" + this.getWhen() + ")";
+        return "BjoernScenario(name=" + this.getName() + ", deprecated=" + this.isDeprecated() + ", when=" + this.getWhen() + ")";
     }
 
 }

--- a/src/main/java/de/mehtrick/bjoern/parser/modell/BjoernZGRScenario.java
+++ b/src/main/java/de/mehtrick/bjoern/parser/modell/BjoernZGRScenario.java
@@ -15,11 +15,13 @@ import java.util.List;
  *
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "Scenario", "Given", "When", "Then" })
+@JsonPropertyOrder({ "Scenario", "Deprecated", "Given", "When", "Then" })
 class BjoernZGRScenario implements Serializable {
 
 	@JsonProperty("Scenario")
 	private String scenario;
+	@JsonProperty("Deprecated")
+	private boolean deprecated;
 	@JsonProperty("Given")
 	private List<String> given = null;
 	@JsonProperty("When")
@@ -36,6 +38,16 @@ class BjoernZGRScenario implements Serializable {
 	@JsonProperty("Scenario")
 	public void setScenario(String scenario) {
 		this.scenario = scenario;
+	}
+
+	@JsonProperty("Deprecated")
+	public boolean isDeprecated() {
+		return deprecated;
+	}
+
+	@JsonProperty("Deprecated")
+	public void setDeprecated(boolean deprecated) {
+		this.deprecated = deprecated;
 	}
 
 	@JsonProperty("Given")
@@ -69,6 +81,6 @@ class BjoernZGRScenario implements Serializable {
 	}
 
 	public String toString() {
-		return "BjoernZGRScenario(scenario=" + this.getScenario() + ", given=" + this.getGiven() + ", when=" + this.getWhen() + ", then=" + this.getThen() + ")";
+		return "BjoernZGRScenario(scenario=" + this.getScenario() + ", deprecated=" + this.isDeprecated() + ", given=" + this.getGiven() + ", when=" + this.getWhen() + ", then=" + this.getThen() + ")";
 	}
 }

--- a/src/main/java/de/mehtrick/bjoern/parser/validator/validations/BjoernKeywords.java
+++ b/src/main/java/de/mehtrick/bjoern/parser/validator/validations/BjoernKeywords.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 
 public enum BjoernKeywords {
 
-    GIVEN("Given:"), WHEN("When:"), THEN("Then:"), BACKGROUND("Background:"), FEATURE("Feature:"), VERSION("Version:"), REFERENCE("Reference:"), CHANGELOG("Changelog:"), SCENARIO("- Scenario:"), SCENARIOS("Scenarios:"), STATEMENT("-");
+    GIVEN("Given:"), WHEN("When:"), THEN("Then:"), BACKGROUND("Background:"), FEATURE("Feature:"), VERSION("Version:"), REFERENCE("Reference:"), CHANGELOG("Changelog:"), DEPRECATED("Deprecated:"), SCENARIO("- Scenario:"), SCENARIOS("Scenarios:"), STATEMENT("-");
 
     public String keyword;
 

--- a/src/main/java/de/mehtrick/bjoern/parser/validator/validations/BjoernValidations.java
+++ b/src/main/java/de/mehtrick/bjoern/parser/validator/validations/BjoernValidations.java
@@ -41,6 +41,11 @@ public enum BjoernValidations {
         protected void validate(String[] lines, int index) throws BjoernValidationsException {
             new MissingStatementContent(errorText).validate(lines,index);
         }
+    }, DEPRECATED_VALIDATION("Invalid Deprecated: declaration. %s") {
+        @Override
+        protected void validate(String[] lines, int index) throws BjoernValidationsException {
+            new DeprecatedValidation(errorText).validate(lines,index);
+        }
     };
 
     final String errorText;

--- a/src/main/java/de/mehtrick/bjoern/parser/validator/validations/DeprecatedValidation.java
+++ b/src/main/java/de/mehtrick/bjoern/parser/validator/validations/DeprecatedValidation.java
@@ -1,0 +1,48 @@
+package de.mehtrick.bjoern.parser.validator.validations;
+
+import de.mehtrick.bjoern.parser.validator.BjoernValidationsException;
+
+public class DeprecatedValidation extends AbstractValidation {
+
+    private static final int EXPECTED_INDENTATION = 4;
+
+    public DeprecatedValidation(String errorText) {
+        super(errorText);
+    }
+
+    @Override
+    public void validate(String[] lines, int index) throws BjoernValidationsException {
+        String trimmedLine = getTrimmedLine(lines, index);
+        if (!trimmedLine.startsWith(BjoernKeywords.DEPRECATED.keyword)) {
+            return;
+        }
+
+        boolean scenariosSeen = false;
+        for (int i = 0; i < index; i++) {
+            if (getTrimmedLine(lines, i).startsWith(BjoernKeywords.SCENARIOS.keyword)) {
+                scenariosSeen = true;
+                break;
+            }
+        }
+        if (!scenariosSeen) {
+            throw new BjoernValidationsException(index, errorText,
+                    "Deprecated: is only allowed inside a Scenarios block, but was found at root level");
+        }
+
+        if (!lines[index].startsWith(createEmptySpaces(EXPECTED_INDENTATION) + BjoernKeywords.DEPRECATED.keyword)) {
+            int spacesCount = lines[index].indexOf(BjoernKeywords.DEPRECATED.keyword);
+            throw new BjoernValidationsException(index, errorText,
+                    "Deprecated: must be indented with " + EXPECTED_INDENTATION + " spaces but found " + spacesCount);
+        }
+
+        String afterColon = trimmedLine.substring(trimmedLine.indexOf(':') + 1).trim();
+        if (afterColon.isEmpty()) {
+            throw new BjoernValidationsException(index, errorText,
+                    "Deprecated: requires a boolean value (true or false) but none was provided");
+        }
+        if (!"true".equals(afterColon) && !"false".equals(afterColon)) {
+            throw new BjoernValidationsException(index, errorText,
+                    "Deprecated: value must be true or false but found \"" + afterColon + "\"");
+        }
+    }
+}

--- a/src/main/resources/asciidoc.ftlh
+++ b/src/main/resources/asciidoc.ftlh
@@ -40,7 +40,7 @@ Changelog: ${changelogAsAsciidoc}
 
 
 <#list scenarios as scenario>
-== Scenario: ${scenario.name}
+== Scenario: ${scenario.name}<#if scenario.deprecated> [.red]#Veraltet#</#if>
 [cols="10%,90%"]
 |===
 <#if scenario.given??>

--- a/src/test/java/de/mehtrick/bjoern/BjoernParserTest.java
+++ b/src/test/java/de/mehtrick/bjoern/BjoernParserTest.java
@@ -30,6 +30,14 @@ public class BjoernParserTest {
 	}
 
 	@Test
+	public void testDeprecatedScenarioParsed() {
+		Bjoern bjoern = new BjoernParser().parseSpec("src/test/resources/deprecated.zgr", Charset.defaultCharset());
+		assertThat(bjoern.getScenarios()).hasSize(2);
+		assertThat(bjoern.getScenarios().get(0).isDeprecated()).isTrue();
+		assertThat(bjoern.getScenarios().get(1).isDeprecated()).isFalse();
+	}
+
+	@Test
 	public void testBjoernWithMarkdownLinkReference() {
 		String path = "src/test/resources/reference.zgr";
 		Bjoern bjoern = new BjoernParser().parseSpec(path, Charset.defaultCharset());

--- a/src/test/java/de/mehtrick/bjoern/asciidoc/AsciiDocBuildTest.java
+++ b/src/test/java/de/mehtrick/bjoern/asciidoc/AsciiDocBuildTest.java
@@ -140,4 +140,17 @@ public class AsciiDocBuildTest {
 		assertThat(content).doesNotContain("== Git History");
 	}
 
+	@Test
+	@DisplayName("Test Doc Generation with deprecated scenario shows Veraltet hint")
+	public void testDocGenerationWithDeprecatedScenario() throws IOException, BjoernMissingPropertyException, NotSupportedJunitVersionException {
+		BjoernDocApplication.main(new String[]{"path=src/test/resources/deprecated.zgr", "docdir=src/gen/resources"});
+		File generatedFile = new File("src/gen/resources/deprecated.adoc");
+		assertThat(generatedFile).exists();
+		String content = new String(Files.readAllBytes(generatedFile.toPath()), StandardCharsets.UTF_8);
+		assertThat(content).contains("= Test mit Deprecated Scenarios");
+		assertThat(content).contains("== Scenario: Veraltetes Szenario [.red]#Veraltet#");
+		assertThat(content).contains("== Scenario: Aktuelles Szenario");
+		assertThat(content).doesNotContain("== Scenario: Aktuelles Szenario [.red]#Veraltet#");
+	}
+
 }

--- a/src/test/java/de/mehtrick/bjoern/generator/builder/BjoernScenarioTestMethodBuilderTest.java
+++ b/src/test/java/de/mehtrick/bjoern/generator/builder/BjoernScenarioTestMethodBuilderTest.java
@@ -59,4 +59,49 @@ class BjoernScenarioTestMethodBuilderTest extends AbstractBuilderTest {
         Assertions.assertThat(mappedScenario.annotations).hasSize(2);
         Assertions.assertThat(mappedScenario.annotations.get(0).type.toString()).isEqualTo(Test.class.getCanonicalName());
     }
+
+    @Test
+    void testDeprecatedScenarioMappedJUnit4() {
+        //given
+        bjoern = getBjoern("src/test/resources/deprecated.zgr");
+
+        //when
+        List<MethodSpec> buildBjoernScenarios = BjoernScenarioTestMethodBuilder.build(bjoern, SupportedJunitVersion.junit4);
+
+        //then
+        Assertions.assertThat(buildBjoernScenarios).hasSize(2);
+        MethodSpec deprecatedScenario = buildBjoernScenarios.get(0);
+        MethodSpec activeScenario = buildBjoernScenarios.get(1);
+
+        Assertions.assertThat(deprecatedScenario.annotations).hasSize(2);
+        Assertions.assertThat(deprecatedScenario.annotations.get(0).type.toString()).isEqualTo(org.junit.Test.class.getCanonicalName());
+        Assertions.assertThat(deprecatedScenario.annotations.get(1).type.toString()).isEqualTo(Deprecated.class.getCanonicalName());
+        Assertions.assertThat(deprecatedScenario.javadoc.toString()).contains("@deprecated Veraltet");
+
+        Assertions.assertThat(activeScenario.annotations).hasSize(1);
+        Assertions.assertThat(activeScenario.annotations.get(0).type.toString()).isEqualTo(org.junit.Test.class.getCanonicalName());
+        Assertions.assertThat(activeScenario.javadoc.toString()).doesNotContain("@deprecated");
+    }
+
+    @Test
+    void testDeprecatedScenarioMappedJUnit5() {
+        //given
+        bjoern = getBjoern("src/test/resources/deprecated.zgr");
+
+        //when
+        List<MethodSpec> buildBjoernScenarios = BjoernScenarioTestMethodBuilder.build(bjoern, SupportedJunitVersion.junit5);
+
+        //then
+        Assertions.assertThat(buildBjoernScenarios).hasSize(2);
+        MethodSpec deprecatedScenario = buildBjoernScenarios.get(0);
+        MethodSpec activeScenario = buildBjoernScenarios.get(1);
+
+        Assertions.assertThat(deprecatedScenario.annotations).hasSize(3);
+        Assertions.assertThat(deprecatedScenario.annotations.get(0).type.toString()).isEqualTo(Test.class.getCanonicalName());
+        Assertions.assertThat(deprecatedScenario.annotations.get(2).type.toString()).isEqualTo(Deprecated.class.getCanonicalName());
+        Assertions.assertThat(deprecatedScenario.javadoc.toString()).contains("@deprecated Veraltet");
+
+        Assertions.assertThat(activeScenario.annotations).hasSize(2);
+        Assertions.assertThat(activeScenario.javadoc.toString()).doesNotContain("@deprecated");
+    }
 }

--- a/src/test/java/de/mehtrick/bjoern/parser/BjoernValidatorTest.java
+++ b/src/test/java/de/mehtrick/bjoern/parser/BjoernValidatorTest.java
@@ -179,6 +179,110 @@ public class BjoernValidatorTest {
     }
 
     @Test
+    public void testDeprecatedValidUsage() {
+        String zgr = "Feature: Feature\r\n" +
+                "Scenarios: \r\n" +
+                "  - Scenario: Scenario \r\n" +
+                "    Deprecated: true\r\n" +
+                "    Given: \r\n" +
+                "      - Ein Benutzer";
+
+        bjoernValidator.validate(zgr, "default");
+    }
+
+    @Test
+    public void testDeprecatedValidUsageFalse() {
+        String zgr = "Feature: Feature\r\n" +
+                "Scenarios: \r\n" +
+                "  - Scenario: Scenario \r\n" +
+                "    Deprecated: false\r\n" +
+                "    Given: \r\n" +
+                "      - Ein Benutzer";
+
+        bjoernValidator.validate(zgr, "default");
+    }
+
+    @Test
+    public void testDeprecatedRootLevel() {
+        String zgr = "Feature: Feature\r\n" +
+                "Deprecated: true\r\n" +
+                "Scenarios: \r\n" +
+                "  - Scenario: Scenario \r\n" +
+                "    Given: \r\n" +
+                "      - Ein Benutzer";
+
+        Assertions.assertThatExceptionOfType(BjoernValidatorException.class).isThrownBy(() -> {
+                    bjoernValidator.validate(zgr, "default");
+                }
+        ).withMessageContaining("ValidationError at line 2:")
+                .withMessageContaining("Deprecated: is only allowed inside a Scenarios block, but was found at root level");
+    }
+
+    @Test
+    public void testDeprecatedNoValue() {
+        String zgr = "Feature: Feature\r\n" +
+                "Scenarios: \r\n" +
+                "  - Scenario: Scenario \r\n" +
+                "    Deprecated:\r\n" +
+                "    Given: \r\n" +
+                "      - Ein Benutzer";
+
+        Assertions.assertThatExceptionOfType(BjoernValidatorException.class).isThrownBy(() -> {
+                    bjoernValidator.validate(zgr, "default");
+                }
+        ).withMessageContaining("ValidationError at line 4:")
+                .withMessageContaining("Deprecated: requires a boolean value (true or false) but none was provided");
+    }
+
+    @Test
+    public void testDeprecatedNonBooleanValue() {
+        String zgr = "Feature: Feature\r\n" +
+                "Scenarios: \r\n" +
+                "  - Scenario: Scenario \r\n" +
+                "    Deprecated: maybe\r\n" +
+                "    Given: \r\n" +
+                "      - Ein Benutzer";
+
+        Assertions.assertThatExceptionOfType(BjoernValidatorException.class).isThrownBy(() -> {
+                    bjoernValidator.validate(zgr, "default");
+                }
+        ).withMessageContaining("ValidationError at line 4:")
+                .withMessageContaining("Deprecated: value must be true or false but found \"maybe\"");
+    }
+
+    @Test
+    public void testDeprecatedWrongIndentation() {
+        String zgr = "Feature: Feature\r\n" +
+                "Scenarios: \r\n" +
+                "  - Scenario: Scenario \r\n" +
+                "  Deprecated: true\r\n" +
+                "    Given: \r\n" +
+                "      - Ein Benutzer";
+
+        Assertions.assertThatExceptionOfType(BjoernValidatorException.class).isThrownBy(() -> {
+                    bjoernValidator.validate(zgr, "default");
+                }
+        ).withMessageContaining("ValidationError at line 4:")
+                .withMessageContaining("Deprecated: must be indented with 4 spaces but found 2");
+    }
+
+    @Test
+    public void testDeprecatedBeforeScenariosKeyword() {
+        String zgr = "Feature: Feature\r\n" +
+                "  Deprecated: true\r\n" +
+                "Scenarios: \r\n" +
+                "  - Scenario: Scenario \r\n" +
+                "    Given: \r\n" +
+                "      - Ein Benutzer";
+
+        Assertions.assertThatExceptionOfType(BjoernValidatorException.class).isThrownBy(() -> {
+                    bjoernValidator.validate(zgr, "default");
+                }
+        ).withMessageContaining("ValidationError at line 2:")
+                .withMessageContaining("Deprecated: is only allowed inside a Scenarios block, but was found at root level");
+    }
+
+    @Test
     public void changelogMultilineFoldedBlock() {
         String zgr = "Feature: Feature\r\n" +
                 "Changelog: >\r\n" +

--- a/src/test/java/de/mehtrick/bjoern/parser/BjoernValidatorTest.java
+++ b/src/test/java/de/mehtrick/bjoern/parser/BjoernValidatorTest.java
@@ -21,8 +21,8 @@ public class BjoernValidatorTest {
         Assertions.assertThatExceptionOfType(BjoernValidatorException.class).isThrownBy(() -> {
                     bjoernValidator.validate("  WrongKeyword     \r\n      \r\n anotherWrongOne", "defaultpath");
                 }
-        ).withMessageContaining("ValidationError at line 1: The line starts with an invalid Keyword. Found \"  WrongKeyword     \". Allowed Keywords are: Given:,When:,Then:,Background:,Feature:,Version:,Reference:,Changelog:,- Scenario:,Scenarios:,-. This check is case-sensitive!")
-                .withMessageContaining("ValidationError at line 3: The line starts with an invalid Keyword. Found \" anotherWrongOne\". Allowed Keywords are: Given:,When:,Then:,Background:,Feature:,Version:,Reference:,Changelog:,- Scenario:,Scenarios:,-. This check is case-sensitive!");
+        ).withMessageContaining("ValidationError at line 1: The line starts with an invalid Keyword. Found \"  WrongKeyword     \". Allowed Keywords are: Given:,When:,Then:,Background:,Feature:,Version:,Reference:,Changelog:,Deprecated:,- Scenario:,Scenarios:,-. This check is case-sensitive!")
+                .withMessageContaining("ValidationError at line 3: The line starts with an invalid Keyword. Found \" anotherWrongOne\". Allowed Keywords are: Given:,When:,Then:,Background:,Feature:,Version:,Reference:,Changelog:,Deprecated:,- Scenario:,Scenarios:,-. This check is case-sensitive!");
     }
 
     @Test

--- a/src/test/resources/deprecated.zgr
+++ b/src/test/resources/deprecated.zgr
@@ -1,0 +1,17 @@
+Feature: Test mit Deprecated Scenarios
+Scenarios:
+  - Scenario: Veraltetes Szenario
+    Deprecated: true
+    Given:
+      - Ein Benutzer
+    When:
+      - Benutzer tut etwas
+    Then:
+      - Ergebnis ist korrekt
+  - Scenario: Aktuelles Szenario
+    Given:
+      - Ein Benutzer
+    When:
+      - Benutzer tut etwas
+    Then:
+      - Ergebnis ist korrekt


### PR DESCRIPTION
Closes #92

Adds an optional `Deprecated: true` field on scenarios.

Changes:
- Parser model: `BjoernZGRScenario` / `BjoernScenario` now carry a boolean `deprecated` flag.
- Validator: `Deprecated:` is accepted as a valid keyword.
- Java generator: deprecated scenarios generate `@Deprecated` plus a `@deprecated Veraltet` Javadoc tag on the test method.
- Doc generator: deprecated scenarios render `[.red]#Veraltet#` next to the scenario title in AsciiDoc.
- Tests: new `deprecated.zgr` spec plus coverage for parser, scenario builder (JUnit 4/5) and AsciiDoc generation.

Note: Root-level deprecation is intentionally not implemented, only per-scenario deprecation.